### PR TITLE
Bump maxAge, add profile list server options

### DIFF
--- a/deployments/dssg2020/config/common.yaml
+++ b/deployments/dssg2020/config/common.yaml
@@ -19,7 +19,7 @@ jupyterhub:
         kubespawner_override:
           cpu_guarantee: 7 
           cpu_limit: 8
-          mem_guarantee: 30G 
+          mem_guarantee: 28G 
           mem_limit: 32G
     cpu:
       limit: 2

--- a/deployments/dssg2020/config/common.yaml
+++ b/deployments/dssg2020/config/common.yaml
@@ -10,6 +10,17 @@ jupyterhub:
     defaultUrl: "/rstudio"
 #    serviceAccountName: jovyan #must create separately, otherwise use 'default'
     startTimeout: 600
+    profileList:
+      - display_name: "2 CPU, 8GB RAM"
+        description: "https://github.com/DSSG-eiCompare/jhub-rstudio"
+        default: true
+      - display_name: "8 CPU, 32GB RAM"
+        description: "https://github.com/DSSG-eiCompare/jhub-rstudio"
+        kubespawner_override:
+          cpu_guarantee: 7 
+          cpu_limit: 8
+          mem_guarantee: 30G 
+          mem_limit: 32G
     cpu:
       limit: 2
       guarantee: 1

--- a/deployments/dssg2020/config/common.yaml
+++ b/deployments/dssg2020/config/common.yaml
@@ -58,9 +58,9 @@ jupyterhub:
             - >
               test -L /home/jovyan/shared || ln -s /srv/shared /home/jovyan/shared
 
-  # automatically terminate pods after 12 hours 
+  # automatically terminate pods after 24 hours 
   cull:
-    maxAge: 43200  
+    maxAge: 86400  
   
   auth:
     type: custom


### PR DESCRIPTION
Add option for users to reserve a full node (Note that memory requests don't translate exactly   `mem_guarantee: 28G --> 30064771072 (94%)` Might want to use GiB units in future?....

```
  Namespace                  Name                             CPU Requests  CPU Limits  Memory Requests    Memory Limits       AGE
  ---------                  ----                             ------------  ----------  ---------------    -------------       ---
  dssg2020-prod              continuous-image-puller-gdlww    0 (0%)        0 (0%)      0 (0%)             0 (0%)              6m4s
  dssg2020-staging           continuous-image-puller-6vztn    0 (0%)        0 (0%)      0 (0%)             0 (0%)              6m4s
  dssg2020-staging           jupyter-scottyhq                 7 (88%)       8 (101%)    30064771072 (94%)  34359738368 (107%)  8m13s
  kube-system                aws-node-gzl66                   10m (0%)      0 (0%)      0 (0%)             0 (0%)              6m54s
  kube-system                kube-proxy-pq7cm                 100m (1%)     0 (0%)      0 (0%)             0 (0%)              6m54s
```